### PR TITLE
Only one notification per deal

### DIFF
--- a/mydealz_preisfehler.sh
+++ b/mydealz_preisfehler.sh
@@ -20,6 +20,9 @@ last_deals=$(paste -sd'|' $path/.tmp_file_lastknowndeals)
 sleep 1
 #wellp, thats a long pipe
 wget --header "Cookie: sort_by=%22new%22" -qO- https://www.mydealz.de/search?q=$mydealz_search -O - | grep -Eo "(http|https)://[a-zA-Z0-9./?=_-]*" | awk '!seen[$0]++' | grep '/deals/' | tail -n +2 > $path/.tmp_file_lastknowndeals
+if [ -z $last_deals ]; then
+  last_deals=$(paste -sd'|' $path/.tmp_file_lastknowndeals | cut -d"|" -f 2-)
+fi
 sleep 1
 for new_deal in `cat $path/.tmp_file_lastknowndeals`; do
   if [[ ! $new_deal =~ $(echo ^\($last_deals\)$) ]]; then


### PR DESCRIPTION
Schleife hinzugefügt, dass Benachrichtigungen für einen Deal nur einmal versendet werden. Auch wenn der vorherige Deal gelöscht wird, und ein älterer wieder der oberste Deal der Seite ist.
Zusätzlich wird beim erstmaligen ausführen, nur der neuste Deal zum testen verwendet.